### PR TITLE
Add private no-args constructor to Money/BigMoney for use as JPA embeddable (#23)

### DIFF
--- a/src/main/java/org/joda/money/BigMoney.java
+++ b/src/main/java/org/joda/money/BigMoney.java
@@ -411,6 +411,15 @@ public final class BigMoney implements BigMoneyProvider, Comparable<BigMoneyProv
 
     //-----------------------------------------------------------------------
     /**
+     * Private no-args constructor, for use as JPA Embeddable (for example).
+     */
+    @SuppressWarnings("unused")
+    private BigMoney() {
+        this.currency = null;
+        this.amount = null;
+    }
+
+    /**
      * Constructor, creating a new monetary instance.
      * 
      * @param currency  the currency to use, not null

--- a/src/main/java/org/joda/money/Money.java
+++ b/src/main/java/org/joda/money/Money.java
@@ -366,6 +366,14 @@ public final class Money implements BigMoneyProvider, Comparable<BigMoneyProvide
 
     //-----------------------------------------------------------------------
     /**
+     * Private no-args constructor, for use as JPA Embeddable (for example).
+     */
+    @SuppressWarnings("unused")
+    private Money() {
+        this.money = null;
+    }
+
+    /**
      * Constructor, creating a new monetary instance.
      * 
      * @param money  the underlying money, not null


### PR DESCRIPTION
As per suggestion in https://github.com/JodaOrg/joda-money/issues/23 I have added private no-args constructors to allow instantiation through reflection. This allows use as, for example, a JPA embeddable.

Perhaps worth pointing out that the excellent Immutables project (https://immutables.github.io/) has an option to add private no-args constructors for exactly this purpose.
